### PR TITLE
fix when mutation failed relativeNodes is null cause crash

### DIFF
--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -91,7 +91,10 @@ export default class Store {
         //  nodes - all nodes added (Array)
         //  changes - changes to make to db (Object)
         const {relativeNodes, nodes, changes} = normalize(data[queryName], fragment);
-
+        if (!relativeNodes) {
+            relativeNodes = [];
+        }
+        
         // Make changes in local DB
         this.db.mergeChanges(changes);
 


### PR DESCRIPTION
if  mutation failed, `relativeNodes` will be null, it will cause a crash for checkMutationListeners
